### PR TITLE
Added SNS and SQS

### DIFF
--- a/import-service/handler.js
+++ b/import-service/handler.js
@@ -37,7 +37,19 @@ module.exports = {
     };
 
     const parse = (stream) => new Promise((resolve, reject) => {
-      stream.on('data', (data) => console.log('Record:', data));
+      const sqs = new AWS.SQS();
+      stream.on('data', (data) => {
+        sqs.sendMessage({
+          QueueUrl: process.env.SQS_URL,
+          MessageBody: JSON.stringify(data),
+        }, (err) => {
+          if (err) {
+            console.log(`Error sending message to SQS: ${err}`);
+          } else {
+            console.log(`Record sent to SQS: ${JSON.stringify(data)}`);
+          }
+        });
+      });
       stream.on('error', (error) => {
         console.log(error);
         reject();

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -14,8 +14,13 @@ provider:
       Action:
         - "s3:*"
       Resource: "arn:aws:s3:::my-shop-books/*"
+    - Effect: "Allow"
+      Action:
+        - "sqs:SendMessage"
+      Resource: "arn:aws:sqs:eu-west-1:720133763777:catalogItemsQueue"
   environment:
     BUCKET: my-shop-books
+    SQS_URL: "https://sqs.eu-west-1.amazonaws.com/720133763777/catalogItemsQueue"
 
 functions:
   importProductsFile:

--- a/product-service/__tests__/catalogBatchProcess.test.js
+++ b/product-service/__tests__/catalogBatchProcess.test.js
@@ -1,0 +1,129 @@
+import AWS from 'aws-sdk';
+import { handler } from '../catalogBatchProcess';
+
+jest.mock('aws-sdk', () => {
+  const dynamodbMock = {
+    batchWrite: jest.fn().mockReturnThis(),
+    promise: jest.fn(),
+  };
+  const snsMock = {
+    publish: jest.fn().mockReturnThis(),
+    promise: jest.fn(),
+  };
+  const SNS = jest.fn(() => snsMock);
+  const DynamoDB = {
+    DocumentClient: jest.fn(() => dynamodbMock),
+  };
+  return {
+    SNS,
+    DynamoDB,
+  };
+});
+
+const books = [{
+  id: '1',
+  title: 'Book 1',
+  description: 'This is book 1',
+  price: 10,
+}, {
+  id: '2',
+  title: 'Book 2',
+  description: 'This is book 2',
+}];
+
+const log = jest.spyOn(console, 'log').mockImplementation();
+
+describe('catalogBatchProcess', () => {
+  let snsMock;
+  let dynamodbMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    snsMock = new AWS.SNS();
+    dynamodbMock = new AWS.DynamoDB.DocumentClient();
+  });
+
+  test('should return early if no books are received', async () => {
+    const event = { Records: [] };
+    await handler(event);
+    expect(dynamodbMock.batchWrite).not.toHaveBeenCalled();
+    expect(snsMock.publish).not.toHaveBeenCalled();
+  });
+
+  test('should put items to DynamoDB and publish SNS messages', async () => {
+    const records = [{ body: JSON.stringify(books[0]) }, { body: JSON.stringify(books[1]) }];
+
+    const event = {
+      Records: records,
+    };
+
+    const mockBatchWrite = jest.fn((params) => {
+      expect(params).toEqual({
+        RequestItems: {
+          [process.env.PRODUCTS_TABLE_NAME]: [
+            {
+              PutRequest: {
+                Item: { ...books[0] },
+              },
+            },
+            {
+              PutRequest: {
+                Item: { ...books[1], price: 0 },
+              },
+            },
+          ],
+        },
+      });
+      return {
+        promise: () => Promise.resolve({}),
+      };
+    });
+
+    dynamodbMock.batchWrite.mockImplementation(mockBatchWrite);
+
+    const snsMessages = [];
+    const mockPublish = jest.fn((params) => {
+      snsMessages.push(params);
+      return {
+        promise: () => Promise.resolve({}),
+      };
+    });
+
+    snsMock.publish.mockImplementation(mockPublish);
+
+    await handler(event);
+
+    expect(dynamodbMock.batchWrite).toHaveBeenCalledTimes(1);
+
+    expect(snsMock.publish).toHaveBeenCalledTimes(2);
+    expect(snsMessages).toEqual([{
+      TopicArn: process.env.PRODUCTS_SNS_TOPIC_ARN,
+      Message: JSON.stringify(`New products have been added: ${books[0].title} ${books[0].price}$`),
+      MessageAttributes: {
+        price: {
+          DataType: 'Number',
+          StringValue: books[0].price,
+        },
+      },
+    }, {
+      TopicArn: process.env.PRODUCTS_SNS_TOPIC_ARN,
+      Message: JSON.stringify(`New products have been added: ${books[1].title} 0$`),
+      MessageAttributes: {
+        price: {
+          DataType: 'Number',
+          StringValue: 0,
+        },
+      },
+    }]);
+  });
+
+  test('should catch and log errors', async () => {
+    const event = { Records: [{ body: JSON.stringify(books[0]) }] };
+    const error = new Error('DynamoDB error');
+    dynamodbMock.batchWrite.mockImplementation(() => ({
+      promise: () => Promise.reject(error),
+    }));
+    await handler(event);
+    expect(log.mock.calls[2]).toEqual(['Error:', error]);
+  });
+});

--- a/product-service/catalogBatchProcess.js
+++ b/product-service/catalogBatchProcess.js
@@ -1,0 +1,57 @@
+const AWS = require('aws-sdk');
+
+const dynamodb = new AWS.DynamoDB.DocumentClient();
+const { PRODUCTS_TABLE_NAME, PRODUCTS_SNS_TOPIC_ARN } = process.env;
+
+exports.handler = async (event) => {
+  console.log('Incoming request:', event);
+
+  const books = event.Records.map((record) => JSON.parse(record.body)).filter(({ id }) => id);
+  console.log(`Received ${books.length} books`);
+
+  if (!books.length) {
+    return;
+  }
+
+  const bookItems = books.map((book) => ({
+    PutRequest: {
+      Item: {
+        id: book.id,
+        title: book.title,
+        description: book.description,
+        price: book.price || 0,
+      },
+    },
+  }));
+
+  const params = {
+    RequestItems: {
+      [PRODUCTS_TABLE_NAME]: bookItems,
+    },
+  };
+
+  try {
+    const result = await dynamodb.batchWrite(params).promise();
+    console.log('Batch write result:', result);
+
+    const sns = new AWS.SNS();
+
+    await Promise.all(books.map((book) => {
+      const snsMessage = `New products have been added: ${book.title} ${book.price || 0}$`;
+      const snsParams = {
+        TopicArn: PRODUCTS_SNS_TOPIC_ARN,
+        Message: JSON.stringify(snsMessage),
+        MessageAttributes: {
+          price: {
+            DataType: 'Number',
+            StringValue: book.price || 0,
+          },
+        },
+      };
+      console.log(`Sent SNS message for new products: ${snsMessage}`);
+      return sns.publish(snsParams).promise();
+    }));
+  } catch (error) {
+    console.log('Error:', error);
+  }
+};

--- a/product-service/serverless.yml
+++ b/product-service/serverless.yml
@@ -35,12 +35,23 @@ provider:
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
         - dynamodb:DescribeTable
+        - dynamodb:BatchWriteItem
       Resource:
         - "arn:aws:dynamodb:eu-west-1:720133763777:table/products"
         - "arn:aws:dynamodb:eu-west-1:720133763777:table/stocks"
+    - Effect: Allow
+      Action:
+        - sns:Publish
+      Resource: !Ref createProductTopic
+    - Effect: Allow
+      Action:
+        - sqs:ReceiveMessage
+        - sqs:DeleteMessage
+      Resource: !GetAtt catalogItemsQueue.Arn
   environment:
     PRODUCTS_TABLE_NAME: products
     STOCKS_TABLE_NAME: stocks
+    PRODUCTS_SNS_TOPIC_ARN: !Ref createProductTopic
 
 # you can add statements to the Lambda function's IAM Role here
 #  iam:
@@ -91,7 +102,13 @@ functions:
       - http:
           path: /products
           method: post
-#    The following are a few example events you can configure
+  catalogBatchProcess:
+    handler: catalogBatchProcess.handler
+    events:
+      - sqs:
+          batchSize: 5
+          arn: !GetAtt catalogItemsQueue.Arn
+
 #    NOTE: Please make sure to change your handler code to work with those events
 #    Check the event documentation for details
 #    events:
@@ -142,6 +159,38 @@ functions:
 #     NewOutput:
 #       Description: "Description for the output"
 #       Value: "Some output value"
+resources:
+  Resources:
+    catalogItemsQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: catalogItemsQueue
+    createProductTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: Create Product Topic
+        TopicName: createProductTopic
+    snsSubscription:
+      Type: AWS::SNS::Subscription
+      Properties:
+        Protocol: email
+        TopicArn:
+          Ref: createProductTopic
+        Endpoint: rusgrishchuk@gmail.com
+        FilterPolicy:
+          price:
+            - {"numeric": [">", 50 ]}
+    snsSubscriptionLowPrice:
+      Type: AWS::SNS::Subscription
+      Properties:
+        Protocol: email
+        TopicArn:
+          Ref: createProductTopic
+        Endpoint: Ruslan_Hryshchuk@epam.com
+        FilterPolicy:
+          price:
+            - { "numeric": [ "<=", 50 ] }
+
 package:
   exclude:
     - __tests__/**


### PR DESCRIPTION
Tasks 6.1-6.4 **Done**
+15 (All languages) - catalogBatchProcess lambda is covered by unit tests **Done**
+15 (All languages) - set a Filter Policy for SNS createProductTopic in serverless.yml and create an additional email subscription to distribute messages to different emails depending on the filter for any product attribute **Done**